### PR TITLE
Fix video list sorting order

### DIFF
--- a/video_generator.py
+++ b/video_generator.py
@@ -66,6 +66,7 @@ for para in paragraphs[:-1]:
 
 clips = []
 l_files = os.listdir("videos")
+l_files.sort(key=lambda f: int(re.sub('\D', '', f)))
 for file in l_files:
     clip = VideoFileClip(f"videos/{file}")
     clips.append(clip)


### PR DESCRIPTION
Default os.listdir() creates video list in incorrect order:
```
videos/video1.mp4
videos/video10.mp4
videos/video11.mp4
videos/video12.mp4
videos/video13.mp4
videos/video14.mp4
videos/video15.mp4
videos/video16.mp4
videos/video17.mp4
videos/video18.mp4
videos/video19.mp4
videos/video2.mp4
videos/video20.mp4
videos/video21.mp4
videos/video22.mp4
videos/video23.mp4
videos/video24.mp4
videos/video25.mp4
videos/video26.mp4
videos/video3.mp4
videos/video4.mp4
videos/video5.mp4
videos/video6.mp4
videos/video7.mp4
videos/video8.mp4
videos/video9.mp4
```

Video names needs to be additionally sorted for Final Video to make sense.